### PR TITLE
Add log summary analysis

### DIFF
--- a/py/analysis/__init__.py
+++ b/py/analysis/__init__.py
@@ -2,3 +2,4 @@ from .data_collection import get_info, get_planning_info
 from .anova import perform_ANOVA, perform_planning_analysis, perform_ANOVA_z
 from .plots import plot_distributions, plot_gain_heatmaps, plot_gain_lines
 from .ranking import build_full_ranking_table, rank_models, rank_models_prompts
+from .log_summary import analyze_log_summary

--- a/py/analysis/log_summary.py
+++ b/py/analysis/log_summary.py
@@ -1,0 +1,142 @@
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def analyze_log_summary(general_config: dict, out_dir: str) -> None:
+    """Analyse LLM scoring log summary for failures and run counts.
+
+    Parameters
+    ----------
+    general_config : dict
+        Repository configuration used to determine expected prompts.
+    out_dir : str
+        Directory where analysis figures and tables will be saved.
+    """
+    log_path = os.path.join("outputs", "llm_scoring", "log_summary.csv")
+    if not os.path.exists(log_path):
+        print(f"[WARN] {log_path} not found. Skipping log summary analysis.")
+        return
+
+    abstr_path = os.path.join("outputs", "maps", "map_abstractability.csv")
+    df = pd.read_csv(log_path)
+
+    # Derive map size from map name and join abstractability information
+    df["map_size"] = df["map_name"].str.extract(r"map_(\d+)x").astype(int)
+    if os.path.exists(abstr_path):
+        df_abstr = pd.read_csv(abstr_path)
+        df = df.merge(df_abstr, on="map_name", how="left")
+    else:
+        df["abstractability"] = "unknown"
+
+    os.makedirs(out_dir, exist_ok=True)
+    plot_dir = os.path.join(out_dir, "log_summary")
+    os.makedirs(plot_dir, exist_ok=True)
+
+    # ----------- Aggregations -----------
+    model_fail = df.groupby("model_name")["num_fail"].sum().sort_values(ascending=False)
+    prompt_fail = df.groupby("prompt_idx")["num_fail"].sum().sort_values(ascending=False)
+    avg_runs_model = df.groupby("model_name")["total_runs"].mean().sort_values(ascending=False)
+    avg_runs_prompt = df.groupby("prompt_idx")["total_runs"].mean().sort_values(ascending=False)
+    avg_runs_model_prompt = (
+        df.groupby(["model_name", "prompt_idx"])["total_runs"].mean().reset_index()
+    )
+    avg_runs_size = df.groupby("map_size")["total_runs"].mean().sort_index()
+    avg_runs_abstr = df.groupby("abstractability")["total_runs"].mean()
+
+    # Save tables
+    model_fail.to_csv(os.path.join(plot_dir, "model_failures.csv"))
+    prompt_fail.to_csv(os.path.join(plot_dir, "prompt_failures.csv"))
+    avg_runs_model.to_csv(os.path.join(plot_dir, "avg_runs_per_model.csv"))
+    avg_runs_prompt.to_csv(os.path.join(plot_dir, "avg_runs_per_prompt.csv"))
+    avg_runs_model_prompt.to_csv(os.path.join(plot_dir, "avg_runs_model_prompt.csv"), index=False)
+    avg_runs_size.to_csv(os.path.join(plot_dir, "avg_runs_map_size.csv"))
+    avg_runs_abstr.to_csv(os.path.join(plot_dir, "avg_runs_abstractability.csv"))
+
+    # ----------- Plots -----------
+    plt.figure(figsize=(8, 4))
+    model_fail.plot(kind="bar")
+    plt.ylabel("Failures")
+    plt.title("Total failures by model")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "failures_by_model.png"))
+    plt.close()
+
+    plt.figure(figsize=(8, 4))
+    prompt_fail.plot(kind="bar")
+    plt.ylabel("Failures")
+    plt.title("Total failures by prompt")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "failures_by_prompt.png"))
+    plt.close()
+
+    plt.figure(figsize=(8, 4))
+    avg_runs_model.plot(kind="bar")
+    plt.ylabel("Average runs")
+    plt.title("Average runs per model")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "avg_runs_per_model.png"))
+    plt.close()
+
+    plt.figure(figsize=(8, 4))
+    avg_runs_prompt.plot(kind="bar")
+    plt.ylabel("Average runs")
+    plt.title("Average runs per prompt")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "avg_runs_per_prompt.png"))
+    plt.close()
+
+    if not avg_runs_model_prompt.empty:
+        pivot = avg_runs_model_prompt.pivot(
+            index="model_name", columns="prompt_idx", values="total_runs"
+        )
+        plt.figure(figsize=(12, max(4, len(pivot) * 0.4)))
+        sns.heatmap(pivot, annot=True, fmt=".2f")
+        plt.title("Average runs per model/prompt")
+        plt.ylabel("Model")
+        plt.xlabel("Prompt index")
+        plt.tight_layout()
+        plt.savefig(os.path.join(plot_dir, "avg_runs_model_prompt_heatmap.png"))
+        plt.close()
+
+    plt.figure(figsize=(6, 4))
+    avg_runs_size.plot(kind="bar")
+    plt.ylabel("Average runs")
+    plt.title("Average runs by map size")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "avg_runs_by_map_size.png"))
+    plt.close()
+
+    plt.figure(figsize=(6, 4))
+    avg_runs_abstr.plot(kind="bar")
+    plt.ylabel("Average runs")
+    plt.title("Average runs by abstractability")
+    plt.tight_layout()
+    plt.savefig(os.path.join(plot_dir, "avg_runs_by_abstractability.png"))
+    plt.close()
+
+    # ----------- Missing combinations -----------
+    n_prompts = len(general_config.get("llm", {}).get("compositions", []))
+    prompts = list(range(n_prompts))
+    maps = df["map_name"].unique()
+    models = df["model_name"].unique()
+    observed = set(zip(df.model_name, df.prompt_idx, df.map_name))
+    missing_records = []
+    for m in models:
+        for p in prompts:
+            for mp in maps:
+                if (m, p, mp) not in observed:
+                    missing_records.append({
+                        "model_name": m,
+                        "prompt_idx": p,
+                        "map_name": mp,
+                    })
+    if missing_records:
+        df_missing = pd.DataFrame(missing_records)
+        df_missing.to_csv(os.path.join(plot_dir, "missing_combinations.csv"), index=False)
+    else:
+        # create empty file to indicate none missing
+        pd.DataFrame(columns=["model_name", "prompt_idx", "map_name"]).to_csv(
+            os.path.join(plot_dir, "missing_combinations.csv"), index=False
+        )

--- a/py/main_functionality.py
+++ b/py/main_functionality.py
@@ -28,6 +28,7 @@ from .analysis import (
     rank_models_prompts,
     build_full_ranking_table,
     perform_ANOVA_z,
+    analyze_log_summary,
 )
 import pandas as pd
 import time
@@ -398,6 +399,7 @@ def analysis(general_config: dict) -> None:
     df_plan = get_planning_info(root_dir=root_dir)
 
     out_dir = os.path.join("outputs", "analysis")
+    analyze_log_summary(general_config=general_config, out_dir=out_dir)
 
     # Merge model-based and performance-based metrics into 1 df
     df_abstr = (df.groupby(['map_id','model','prompt_id'], observed=True)['best_score'].max().reset_index().rename(columns={'best_score':'model_based_score'}))


### PR DESCRIPTION
## Summary
- analyze log_summary.csv for model/prompt failure rates and run counts
- generate plots and tables for average runs by model, prompt, map size, and abstractability
- expose missing model/prompt/map combinations and integrate analysis step

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a714beb7e88320b5af4b95dc784c3e