### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: Deploy Docs
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+  build-deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: site }
+      - uses: actions/deploy-pages@v4

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -1,0 +1,60 @@
+# Python API
+
+The `py` package contains the high‑level helpers used by the CLI along with lower‑level utilities for prompt generation and scoring.
+
+## CLI helpers
+
+| Function | Module | CLI command | Description |
+|----------|--------|-------------|-------------|
+| `preview_prompts()` | `py.main_functionality` | `preview-prompts` | Render prompts assembled from `config.yml` and `config_prompts.yml`. |
+| `preview_maps()` | `py.main_functionality` | `preview-maps` | Generate map thumbnails and abstractability labels. |
+| `mcts()` | `py.main_functionality` | `mcts` | Run baseline planners on ground and ideal abstractions. |
+| `evaluate_prompt()` | `py.main_functionality` | `score-prompts` | Query an LLM and score returned clusterings. |
+| `llm_abstraction()` | `py.main_functionality` | `benchmark-llm` | End‑to‑end run: prompt → score → MCTS. |
+| `analysis()` | `py.main_functionality` | `analysis` | Summarise benchmarking results into tables and plots. |
+
+Example:
+
+```python
+from py import preview_prompts, load_config
+
+general = load_config("config.yml")
+prompt_cfg = load_config("config_prompts.yml")
+preview_prompts(general_config=general, prompt_config=prompt_cfg)
+```
+
+## Building prompts and querying models
+
+`py.llm.prompts.generate_prompts` stitches together instructions, contexts and a world representation:
+
+```python
+from py.llm.prompts import generate_prompts
+from py.utils import parse_maps, load_config
+
+cfg = load_config("config.yml")
+world = parse_maps(cfg["game"])[0]
+comps = cfg["llm"]["compositions"]
+prompts = generate_prompts(comps, prompt_cfg, world)
+```
+
+Send a prompt to an Ollama model and extract validated clusters:
+
+```python
+from py.llm.ollama import query_llm
+res = query_llm(prompt=prompts[0], runs=2, model="llama2", num_states=16)
+print(res["cleaned_responses"])
+```
+
+## Scoring abstractions
+
+`py.llm.scoring.bisimulation_similarity` evaluates a candidate clustering against the ideal abstraction using transition and reward matrices:
+
+```python
+from core_rust import generate_mdp
+from py.llm.scoring import bisimulation_similarity
+
+mdp = generate_mdp(world)
+score = bisimulation_similarity(candidate, ideal, mdp["T"], mdp["R"])
+```
+
+The score is in `[0,1]` and is used by `evaluate_prompt` and `llm_abstraction` to rank LLM outputs.

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -1,0 +1,21 @@
+# Rust API
+
+The Rust crate in `src/` implements the grid‑world and homomorphism logic. Python calls into it through `pyo3` bindings.
+
+## Core modules
+
+- `core/game/game_logic.rs` – defines the `Game` struct, movement rules and reset logic.
+- `core/abstraction/homomorphism.rs` – BFS over reachable states (`get_all_states`) and partition refinement (`compute_mdp_homomorphism`).
+
+## Python bindings
+
+| Function | Description | Source |
+|----------|-------------|--------|
+| `PyRunner::run(sim_limit, sim_depth, c, gamma, seed, max_turns, runs, debug, show_mcts)` | Execute MCTS on ground or abstract states. | `src/lib.rs` |
+| `generate_mdp(world)` | Return transition matrix `T`, reward matrix `R`, and the optimal abstraction. | `src/lib.rs` |
+| `generate_representations_py(world)` | Produce text/JSON/adjacency representations for prompts. | `src/lib.rs` |
+| `visualize_world_map(world, output_dir)` | Save a PNG of the grid world. | `src/lib.rs` |
+| `visualize_abstraction(world, output_dir)` | Draw state clusters derived from `compute_mdp_homomorphism`. | `src/lib.rs` |
+| `min_turns(world)` / `max_returns(world, gamma)` / `get_number_of_states(world)` | Utility helpers for analyses. | `src/lib.rs` |
+
+These functions are exported through the `core_rust` module and power the Python CLI.

--- a/docs/architecture/data_flow.md
+++ b/docs/architecture/data_flow.md
@@ -1,0 +1,40 @@
+# Data Flow
+
+A full run moves through several stages:
+
+1. **Map generation** – parse maps from `config.yml` and render PNGs.
+2. **Prompt assembly** – `llm.prompts.generate_prompts` composes text from fragments.
+3. **LLM query** – `llm.ollama.query_llm` sends prompts to the local model; optional self‑refinement loops until a valid clustering is extracted.
+4. **Parsing and validation** – `llm.clean.clean_with_regex_and_validate` normalises the response into clusters.
+5. **Scoring** – `llm.scoring.bisimulation_similarity` compares candidate clusters to the ideal abstraction.
+6. **Selection** – the best scoring abstraction is chosen.
+7. **MCTS evaluation** – `evaluation.mcts_llm_evaluation` runs ground, ideal and LLM agents with different budgets and logs metrics.
+
+Outputs (maps, JSON groupings, scores and plots) are written under `outputs/`.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant CLI as CLI (main.py)
+  participant PB as generate_prompts()
+  participant LLM as Ollama LLM
+  participant CLEAN as clean_with_regex_and_validate()
+  participant SCORE as bisimulation_similarity()
+  participant RUN as mcts_llm_evaluation()
+  participant RUST as Rust Core
+
+  User->>CLI: python main.py benchmark-llm -i 0 -m llama2
+  CLI->>PB: generate_prompts(map, composition)
+  PB-->>CLI: prompt
+  CLI->>LLM: query_llm(prompt)
+  LLM-->>CLI: raw_text
+  CLI->>CLEAN: clean_with_regex_and_validate(raw_text)
+  CLEAN-->>CLI: clustering
+  CLI->>SCORE: bisimulation_similarity(clustering, ideal)
+  SCORE-->>CLI: score
+  CLI->>RUN: mcts_llm_evaluation(clustering)
+  RUN->>RUST: simulate/search
+  RUST-->>RUN: results
+  RUN-->>CLI: logs, plots
+  CLI-->>User: outputs/...
+```

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,0 +1,22 @@
+# Modules
+
+## Rust
+
+| Module | Path | Responsibilities | Key items |
+|-------|------|-----------------|-----------|
+| `game` | `src/core/game` | Grid world definition, `Game` and `State` structs, stateless simulator | `simulate`, `get_state` |
+| `abstraction` | `src/core/abstraction` | Compute homomorphisms and build transition/reward matrices | `get_all_states`, `compute_mdp_homomorphism`, `generate_mdp` |
+| `runner` | `src/core/runner.rs` | MCTS search over abstract states | `run_mcts`, `search` |
+| `simulation` | `src/core/simulation` | Forward model utilities | `simulate_many` |
+
+## Python
+
+| Package | Path | Responsibilities | Public API |
+|---------|------|-----------------|-----------|
+| `py.llm.prompts` | `py/llm/prompts.py` | Assemble prompts from configuration fragments | `generate_prompts` |
+| `py.llm.ollama` | `py/llm/ollama.py` | Query local models via Ollama | `query_llm` |
+| `py.llm.clean` | `py/llm/clean.py` | Parse and validate model responses | `clean_with_regex_and_validate` |
+| `py.llm.scoring` | `py/llm/scoring.py` | Bisimulation similarity implementation | `bisimulation_similarity` |
+| `py.evaluation` | `py/evaluation` | Run baseline and LLM MCTS evaluations | `mcts_evaluation`, `mcts_llm_evaluation` |
+| `py.analysis` | `py/analysis` | Post‑processing and plotting of results | `rank_models`, `plot_gain_heatmaps` |
+

--- a/docs/architecture/system.md
+++ b/docs/architecture/system.md
@@ -1,0 +1,40 @@
+# System Architecture
+
+Rust provides the performance‑critical core while Python orchestrates prompting, scoring and planning.
+
+- **Rust core** (`src/core`)
+  - `game` defines the `Game` and `State` types plus a fast stateless simulator.
+  - `abstraction` exposes `get_all_states` and `compute_mdp_homomorphism` to build transition and reward matrices.
+  - `runner` hosts the MCTS search used by Python.
+- **Python layer** (`py/`)
+  - `llm.prompts.generate_prompts` assembles prompts.
+  - `llm.ollama.query_llm` queries local models.
+  - `llm.clean` normalises responses and `llm.scoring.bisimulation_similarity` scores them.
+  - `evaluation` modules run MCTS through the Rust extension.
+
+```mermaid
+flowchart LR
+  subgraph Python Layer
+    CLI["CLI (main.py)"]
+    PB["PromptBuilder"]
+    LLM["LLM Client (Ollama)"]
+    CLEAN["Post-Processor / Cleaner"]
+    SCORE["Bisimulation Scorer"]
+    RUN["Runner (MCTS orchestrator)"]
+  end
+
+  subgraph Rust Core
+    WORLD["World & Game (gridworld)"]
+    HOMO["Homomorphism & Signatures"]
+    MATR["MDP Matrices (T,R)"]
+    SIM["Stateless Simulator & Forward Model"]
+  end
+
+  CLI --> PB --> LLM --> CLEAN --> SCORE
+  SCORE --> RUN
+  RUN --> SIM
+  SIM --> WORLD
+  RUN --> MATR
+  HOMO --> MATR
+  WORLD --> HOMO
+```

--- a/docs/concepts/bisimulation_metric.md
+++ b/docs/concepts/bisimulation_metric.md
@@ -1,0 +1,15 @@
+# Bisimulation Metric
+
+To rate an LLM‑derived clustering, the project computes a similarity score inspired by bisimulation metrics (Thesis). For two ground states \(s_i\) and \(s_j\) in different clusters:
+
+1. Compare immediate rewards: \(|R(s_i,a) - R(s_j,a)|\).
+2. Compare their transition distributions by lifting them to the abstract space. The ground distributions over next clusters are compared with a Wasserstein distance. A Hausdorff lift aggregates over actions.
+
+The final distance \(d(s_i, s_j)\) is the maximum over actions of reward and transition differences. Similarity is then
+\[
+\text{sim}(s_i, s_j) = \frac{1}{1 + d(s_i, s_j)}.
+\]
+
+The **composite z‑score** evaluates an entire clustering by running agents with MCTS. We compute a model‑based score (above) and a performance score from planning returns. Each score is normalised to a z‑value and the difference \(z_s - z_g\) rewards clusters that preserve both theory and practice.
+
+*Example:* if clustering merges symmetric corners, the bisimulation score is near 1 and MCTS returns match the ground agent, yielding a high composite value.

--- a/docs/concepts/mcts.md
+++ b/docs/concepts/mcts.md
@@ -1,0 +1,27 @@
+# MCTS & Abstraction
+
+Monte Carlo Tree Search proceeds in four phases:
+
+1. **Selection** – follow tree policy until an unexpanded node.
+2. **Expansion** – add one child representing a new action.
+3. **Simulation** – roll out a playout to obtain a reward.
+4. **Backpropagation** – update statistics along the path.
+
+Abstract states reduce the branching factor in both expansion and simulation because multiple ground states share one node. The planner operates on abstract identifiers while the stateless simulator translates them to concrete coordinates (Thesis).
+
+The Rust `Runner` switches between abstract and ground actions on every turn:
+
+```rust
+// src/core/runner.rs
+let action = if let Some(mapper) = &self.mapper {
+    let abs_action = agent.run(current_state.clone(), debug, show_mcts);
+    let abs_state = mapper.ground_state_to_abstract(&current_state);
+    let (_, ground_action) =
+        mapper.abstract_state_action_to_ground(&abs_state, abs_action);
+    ground_action
+} else {
+    agent.run(current_state.clone(), debug, show_mcts)
+};
+```
+
+This mapping layer lets MCTS reason over clusters without modifying the underlying environment.

--- a/docs/concepts/mdp_abstraction.md
+++ b/docs/concepts/mdp_abstraction.md
@@ -1,0 +1,9 @@
+# MDPs & Abstraction
+
+An episodic grid world can be described as an MDP \((S, A, T, R, \gamma)\) where states are tile coordinates and actions move the agent. This project abstracts **states** by grouping them into clusters; actions remain unchanged. When two ground states fall into the same cluster, the planner treats them as equivalent.
+
+Homomorphism concepts motivate these clusters: transitions from a member of a cluster should lead to clusters in the same way, and cumulative rewards should match up to a tolerance (Thesis). For small grids this resembles a lax bisimulation: if two positions behave similarly with respect to the goal and obstacles, they can be merged.
+
+Example: in a 3×3 world with the goal at the bottom‑right, corner tiles other than the goal have symmetric behavior. A cluster \(\{(0,0), (0,2), (2,0)\}\) preserves optimal policies by mapping their transitions to equivalent abstract neighbors.
+
+We use **cluster‑based abstractions** rather than vector embeddings to keep the simulator stateless and to retain clear semantics for each abstract state.

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,0 +1,9 @@
+# Concept Overview
+
+This project combines three ideas to evaluate abstractions of grid‑world environments (Thesis).
+
+- **MDP Abstraction** – states of a Markov Decision Process are grouped into clusters that preserve behavior; see [MDPs & Abstraction](mdp_abstraction.md).
+- **Bisimulation Metric** – candidate abstractions are scored by comparing rewards and transition distributions; see [Bisimulation Metric](bisimulation_metric.md).
+- **MCTS with Abstraction** – abstract states shrink the search space for planning agents; see [MCTS & Abstraction](mcts.md).
+
+These components allow LLM‑generated clusters to be evaluated both analytically and through planning performance.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,0 +1,8 @@
+# Contributing & Style
+
+Contributions are welcome. Follow these guidelines:
+
+- Python style is checked with `flake8`; see `docs/flake8-ignores.md` for rules.
+- Run `cargo fmt` and `cargo clippy` for Rust code.
+- Ensure `cargo test` and `pytest` pass before opening a pull request.
+- Describe changes and link to relevant issues when submitting PRs.

--- a/docs/dev/faq.md
+++ b/docs/dev/faq.md
@@ -1,0 +1,13 @@
+# FAQ
+
+**Q: Why Rust and Python?**
+
+A: Rust offers deterministic, fast simulation and matrix generation. Python provides flexibility for prompt engineering and analysis.
+
+**Q: Do I need internet access?**
+
+A: Only for downloading Ollama models; the core simulation runs offline.
+
+**Q: Can I add new maps?**
+
+A: Yes. Add ASCII maps under `game:` in `config.yml` and run `preview-maps` to generate assets.

--- a/docs/dev/testing_ci.md
+++ b/docs/dev/testing_ci.md
@@ -1,0 +1,10 @@
+# Testing & CI
+
+Run unit tests for both languages:
+
+```bash
+cargo test
+pytest
+```
+
+A GitHub Actions workflow builds the documentation and can be extended to run tests on pushes. The provided `docs.yml` workflow deploys MkDocs to GitHub Pages.

--- a/docs/experiments/maps.md
+++ b/docs/experiments/maps.md
@@ -1,0 +1,15 @@
+# Maps & Abstractability
+
+Grid worlds of sizes 3×3, 5×5 and 9×9 are used. Each map hash in `outputs/maps/` includes a PNG preview and its **reduction factor** \(R = |S| / |\Phi(S)|\), the ratio between ground states and abstract clusters (Thesis). Larger grids are possible, but for big models it is best to run on a high-performance cluster.
+
+We categorize maps by abstractability:
+
+- `R = 1` – no useful abstraction.
+- `1 < R < |S|` – partial abstraction; some symmetry.
+- `R = |S|` – perfect abstraction aligning with the optimal homomorphism.
+
+Thumbnails can be generated with:
+
+```bash
+python main.py preview-maps
+```

--- a/docs/experiments/models.md
+++ b/docs/experiments/models.md
@@ -1,0 +1,11 @@
+# Models
+
+Experiments evaluate different local language models served by [Ollama](https://ollama.com/). Families include LLaMA variants and reasoning‑focused models such as DeepSeek‑R1. Results suggest architecture and instruction tuning matter more than raw parameter count (Thesis).
+
+Switch models by passing their names to CLI commands:
+
+```bash
+python main.py benchmark-llm -i 0 -m llama2
+```
+
+Multiple models can be provided: `-m llama2 deepseek-r1`. Ensure the models are installed in Ollama and accessible via the same names.

--- a/docs/experiments/prompts.md
+++ b/docs/experiments/prompts.md
@@ -1,0 +1,11 @@
+# Prompts
+
+Prompt compositions pull fragments from `config_prompts.yml` to form instructions, context and expected outputs. The `llm.prompts.generate_prompts` utility assembles these pieces for each map (Thesis).
+
+Fragments include roles (e.g., `role1` – expert in decision‑making), relations (`relation2` – group by spatial behaviour) and outputs (`out1` – list of lists). By varying compositions the experiments test how guidance affects abstraction quality.
+
+Preview all generated prompts with:
+
+```bash
+python main.py preview-prompts
+```

--- a/docs/experiments/reproduce.md
+++ b/docs/experiments/reproduce.md
@@ -1,0 +1,17 @@
+# Reproducing Thesis Results
+
+1. Install dependencies via `./setup.sh`.
+2. Use `config.yml` and `config_prompts.yml` as provided.
+3. For each model and prompt index run:
+
+```bash
+python main.py benchmark-llm -i 0 -m llama2
+```
+
+4. After all runs finish, generate ranking tables and plots:
+
+```bash
+python main.py analysis
+```
+
+Outputs appear under `outputs/` with per‑map folders containing scores and MCTS plots (Thesis).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# LLM-Based State Abstraction
+
+Rust backend for fast grid‑world simulation + Python orchestration for LLM abstraction and evaluation with MCTS.
+
+Large language models cluster states of a grid world into abstract groups. The Rust core simulates environments and scoring while Python prompts models, cleans their output and evaluates agents with Monte Carlo Tree Search. This project demonstrates how symbolic planning and LLM reasoning can cooperate for efficient decision making (Thesis).
+
+## Highlights
+
+- **Stateless simulator in Rust** with Python runners.
+- **LLM‑driven cluster abstractions** inspired by homomorphism ideas.
+- **Dual metrics:** model‑based bisimulation score and performance‑based evaluation; combined into a composite *z* value.
+
+See the [Quickstart](quickstart.md) to run an example or dive into the [Architecture](architecture/system.md) for design details.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart
+
+Follow these steps to run the prototype in minutes.
+
+## Prerequisites
+
+- Linux (tested on Ubuntu 24.04)
+- Python 3.10+
+- `rustup` with a nightly toolchain
+
+## Installation
+
+Clone the repository and install dependencies:
+
+```bash
+./setup.sh
+```
+
+This script installs Python packages from `requirements.txt` and builds the Rust extension.
+
+## Run a demo
+
+Generate map images and metadata:
+
+```bash
+python main.py preview-maps
+```
+
+Score an abstraction for the first prompt using a local model name:
+
+```bash
+python main.py score-prompts -i 0 -m llama2
+```
+
+For a full benchmark that scores and evaluates with MCTS:
+
+```bash
+python main.py benchmark-llm -i 0 -m llama2
+```
+
+Outputs are written to `outputs/`.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,0 +1,59 @@
+# CLI Reference
+
+The entry point is `main.py`, which exposes several commands via `argparse`.
+
+## preview-prompts
+
+Display generated prompts for all maps.
+
+```bash
+python main.py preview-prompts
+```
+
+## preview-maps
+
+Render maps and save PNGs under `outputs/maps/`.
+
+```bash
+python main.py preview-maps
+```
+
+## mcts
+
+Run baseline ground and ideal agents with MCTS.
+
+```bash
+python main.py mcts [-d]
+```
+
+- `-d, --debug` – show the MCTS tree.
+
+## score-prompts
+
+Generate prompts, query a model and score the resulting clustering.
+
+```bash
+python main.py score-prompts -i 0 -m llama2 [-d]
+```
+
+- `-i, --index` (required, repeatable) – prompt index from configuration.
+- `-m, --model` (required, repeatable) – Ollama model name.
+- `-d, --debug` – print intermediate data.
+
+## benchmark-llm
+
+Score prompts and evaluate agents with MCTS.
+
+```bash
+python main.py benchmark-llm -i 0 -m llama2 [-g HASH] [-d]
+```
+
+- `-g, --maps` – restrict to specific map hashes.
+
+## analysis
+
+Produce plots and ranking tables from previous runs.
+
+```bash
+python main.py analysis
+```

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,0 +1,55 @@
+# Configuration Files
+
+Two YAML files drive experiments.
+
+## `config.yml`
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `game` | list of grid maps | Each map is written as ASCII with `G` goal and `X` obstacles. |
+| `mcts_variables.simulation_limit` | list[int] | Number of rollouts per planning step. |
+| `mcts_variables.simulation_depth` | list[int] | Depth of each rollout. |
+| `mcts_variables.runs` | int | Number of evaluation runs. |
+| `mcts_variables.c` | float | UCT exploration constant. |
+| `mcts_variables.gamma` | float | Discount factor. |
+| `mcts_variables.debug` | bool | Print MCTS internals. |
+| `llm.tries` | int | Number of model attempts to harvest valid abstractions. |
+| `llm.compositions` | list | Each entry selects prompt fragments (instruction, necessary_context, background_contexts, representation_key, output). |
+
+### Example
+
+```yaml
+game:
+  - |
+    . . G
+mcts_variables:
+  simulation_limit: [32]
+  simulation_depth: [32]
+  runs: 10
+  c: 1.4
+  gamma: 0.85
+  debug: false
+llm:
+  tries: 5
+  compositions:
+    - instruction: "basic1"
+      necessary_context: "necessary-domain1"
+      background_contexts: []
+      representation_key: "text"
+      output: "out1"
+```
+
+## `config_prompts.yml`
+
+Defines reusable prompt fragments grouped by category (e.g., `instruction`, `necessary_context`, `background_contexts`, `output`). Each entry has an `id` and `val` string.
+
+### Example
+
+```yaml
+instruction:
+  - id: "basic1"
+    val: "Please group these states into abstract states."
+necessary_context:
+  - id: "necessary-domain1"
+    val: "The grid world always has the goal located in the bottom right corner."
+```

--- a/docs/usage/outputs.md
+++ b/docs/usage/outputs.md
@@ -1,0 +1,20 @@
+# Outputs & Artifacts
+
+Results are written to the `outputs/` directory.
+
+## `outputs/maps/`
+
+Created by `preview-maps`. Each map hash gets its own folder containing:
+
+- `world.png` and `abstraction.png` visualisations.
+- `map_abstractability.csv` summarising reduction factor `R` for each map.
+
+## `outputs/llm_scoring/`
+
+Produced by `score-prompts` and `benchmark-llm`. For every map and prompt index the following files are generated:
+
+- `<idx>_<model>_out.json` – extracted clustering.
+- `<idx>_<model>_raw_results.csv` – bisimulation scores and MCTS returns.
+- `<idx>_<model>_mcts_results.png` – plot of agent performance.
+
+Most commands accept seeds or limits in `config.yml` to make runs reproducible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,41 @@
+site_name: LLM-Based State Abstraction
+repo_url: https://github.com/<yourname>/llm-abstraction
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.indexes
+    - toc.integrate
+    - content.code.copy
+    - content.tabs.link
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Concepts:
+      - Overview: concepts/overview.md
+      - MDPs & Abstraction: concepts/mdp_abstraction.md
+      - Bisimulation Metric: concepts/bisimulation_metric.md
+      - MCTS & Abstraction: concepts/mcts.md
+  - Architecture:
+      - System Architecture: architecture/system.md
+      - Data Flow: architecture/data_flow.md
+      - Modules: architecture/modules.md
+  - Usage:
+      - CLI Reference: usage/cli.md
+      - Configuration Files: usage/configuration.md
+      - Outputs & Artifacts: usage/outputs.md
+  - API:
+      - Python API: api/python.md
+      - Rust API: api/rust.md
+  - Experiments:
+      - Reproducing Thesis Results: experiments/reproduce.md
+      - Maps & Abstractability: experiments/maps.md
+      - Prompts: experiments/prompts.md
+      - Models: experiments/models.md
+  - Development:
+      - Testing & CI: dev/testing_ci.md
+      - Contributing & Style: dev/contributing.md
+      - FAQ: dev/faq.md


### PR DESCRIPTION
## Summary
- Refine Python API docs with CLI helper table and examples for prompt generation, LLM querying, and bisimulation scoring
- Streamline Rust API docs to focus on homomorphism, game logic, and Python bindings
- Expand MCTS concept page with code illustrating abstract-to-ground action mapping and note larger map sizes

## Testing
- `mkdocs build`
- `cargo test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a75798cf50832093dcb53620a536ca